### PR TITLE
Changed to nonstrict kotlinx json serialization

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cottontaildb-proto"]
 	path = cottontaildb-proto
-	url = https://github.com/ppanopticon/cottontaildb-proto.git
+	url = https://github.com/vitrivr/cottontaildb-proto.git

--- a/src/main/kotlin/org/vitrivr/cottontail/Cottontail.kt
+++ b/src/main/kotlin/org/vitrivr/cottontail/Cottontail.kt
@@ -27,7 +27,7 @@ fun main(args: Array<String>) {
 
     /* Load config file and start Cottontail DB. */
     Files.newBufferedReader(Paths.get(path)).use { reader ->
-        val config = Json.parse(Config.serializer(), reader.readText())
+        val config = Json.nonstrict.parse(Config.serializer(), reader.readText())
         val catalogue = Catalogue(config)
         val engine = ExecutionEngine(config.executionConfig)
         val server = CottontailGrpcServer(config.serverConfig, catalogue, engine)


### PR DESCRIPTION
Changing to nonstrict kotlinx json serialization to support old config files.

Particularly, to support those config files, that had a setting for `forceUnmapMappedFiles`