### PR TITLE
Iron out some bugs with Index Hints. Selection now works.

### DIFF
--- a/src/main/kotlin/org/vitrivr/cottontail/Playground.kt
+++ b/src/main/kotlin/org/vitrivr/cottontail/Playground.kt
@@ -28,10 +28,10 @@ object Playground {
 
 
         this.ddlService.createIndex(
-                CottontailGrpc.CreateIndexMessage.newBuilder().addColumns("feature").setIndex(
+                CottontailGrpc.IndexDefinition.newBuilder().addColumns("feature").setIndex(
                         CottontailGrpc.Index.newBuilder()
                                 .setEntity(CottontailGrpc.Entity.newBuilder().setName("features_audiotranscription").setSchema(CottontailGrpc.Schema.newBuilder().setName("cineast").build()))
-                                .setType(CottontailGrpc.Index.IndexType.LUCENE)
+                                .setType(CottontailGrpc.IndexType.LUCENE)
                                 .setName("feature_index")
                                 .build()
                 ).build()

--- a/src/main/kotlin/org/vitrivr/cottontail/database/index/lsh/LSHIndex.kt
+++ b/src/main/kotlin/org/vitrivr/cottontail/database/index/lsh/LSHIndex.kt
@@ -26,7 +26,7 @@ abstract class LSHIndex<T : VectorValue<*>>(final override val name: Name.IndexN
     final override val produces: Array<ColumnDef<*>> = arrayOf(ColumnDef(this.parent.name.column("distance"), ColumnType.forName("DOUBLE")))
 
     /** The type of [Index] */
-    final override val type: IndexType = IndexType.LSH
+    override val type: IndexType = IndexType.LSH
 
     /** The internal [DB] reference. */
     protected val db = if (parent.parent.parent.config.memoryConfig.forceUnmapMappedFiles) {

--- a/src/main/kotlin/org/vitrivr/cottontail/execution/tasks/entity/knn/IndexScanKnnTask.kt
+++ b/src/main/kotlin/org/vitrivr/cottontail/execution/tasks/entity/knn/IndexScanKnnTask.kt
@@ -6,6 +6,7 @@ import org.vitrivr.cottontail.database.general.query
 import org.vitrivr.cottontail.database.index.Index
 import org.vitrivr.cottontail.database.queries.predicates.KnnPredicate
 import org.vitrivr.cottontail.execution.tasks.basics.ExecutionTask
+import org.vitrivr.cottontail.model.exceptions.QueryException
 import org.vitrivr.cottontail.model.recordset.Recordset
 import org.vitrivr.cottontail.model.values.types.VectorValue
 
@@ -15,13 +16,13 @@ import org.vitrivr.cottontail.model.values.types.VectorValue
  * @author Ralph Gasser
  * @version 1.0.1
  */
-class IndexScanKnnTask<T : VectorValue<*>>(val entity: Entity, val knnPredicate: KnnPredicate<T>, indexHint: Index) : ExecutionTask("EntityIndexedKnnTask[${knnPredicate.column.name}][${knnPredicate.distance::class.simpleName}][${knnPredicate.k}][q=${knnPredicate.query.hashCode()}]") {
+class IndexScanKnnTask<T : VectorValue<*>>(val entity: Entity, val knnPredicate: KnnPredicate<T>, index: Index) : ExecutionTask("EntityIndexedKnnTask[${knnPredicate.column.name}][${knnPredicate.distance::class.simpleName}][${knnPredicate.k}][q=${knnPredicate.query.hashCode()}]") {
 
-    /** The type of the [Index] that should be used.*/
-    private val type = indexHint.type
+    /** The name of the [Index] that should be used.*/
+    val indexName = index.name
 
     override fun execute(): Recordset = this.entity.Tx(readonly = true, columns = arrayOf(knnPredicate.column)).query { tx ->
-        val index = tx.indexes(this.knnPredicate.columns.toTypedArray(), this.type).first()
+        val index = tx.index(this.indexName) ?: throw QueryException.IndexLookupFailedException(this.indexName, "Index ${this.indexName} not found.")
         index.filter(this.knnPredicate)
     } ?: Recordset(this.knnPredicate.columns.toTypedArray(), capacity = 0)
 }


### PR DESCRIPTION
I found some issues with the index hints. With my changes I can now select indexes by name
Issues were:
* SBLSH indexes have parent type (LSH,  src/main/kotlin/org/vitrivr/cottontail/database/index/lsh/LSHIndex.kt), I overrode this in src/main/kotlin/org/vitrivr/cottontail/database/index/lsh/superbit/SuperBitLSHIndex.kt
* In the same file, I added a check whether the index is correctly initialized (if the storage file is corrupted, this can happen, leading to NPEs by calls to config.get(). On another note, NPEs are masked through the execution engine!
* The indexKnnTask was only selecting index based on type of the hinted index, although the execution plan should actually specify the actual index to use. I changed to select on name
* Project didn't compile because Playground.kt used the old proto definition