### PR TITLE
Make Dockerfile self-contained

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
-FROM zenika/kotlin:1.3-jdk11
+FROM zenika/kotlin:1.3-jdk11 AS build
 
-RUN apt-get update
-RUN apt-get install -y git
+COPY . /cottontail-src
+RUN cd /cottontail-src && \
+  ./gradlew distTar && \
+  mkdir cottontaildb-bin && \
+  cd cottontaildb-bin && \
+  tar xf ../build/distributions/cottontaildb-bin.tar
+
+
+FROM zenika/kotlin:1.3-jdk11-slim
+
 RUN mkdir /cottontaildb-data
-
-ADD config.json /cottontaildb-data/
-ADD build/distributions/cottontaildb-bin.tar /
+COPY config.json /cottontaildb-data/
+COPY --from=build /cottontail-src/cottontaildb-bin /
 
 EXPOSE 1865
 

--- a/hooks/post_checkout
+++ b/hooks/post_checkout
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Docker hub does a recursive clone, then checks the branch out,
+# so when a PR adds a submodule (or updates it), it fails.
+git submodule update --init


### PR DESCRIPTION
Having the Dockerfile take care of the build steps means it can be build anywhere using just `docker build`. This means it can be build + hosted on Docker Hub solving https://github.com/vitrivr/cottontaildb/issues/30 . Additionally, it means that Docker hub can build it for each commit. Docker Hub can also easily be set up on people's fork repositories, and so this way people (like myself) can easily get hosted Docker images of their own forks almost immediately.

Closes #30 