### PR TITLE
Fixing build with gradle failed due to deprecated maven repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,9 @@ sourceCompatibility = 1.8
 
 repositories {
     mavenCentral()
-    maven {
-        url "https://kotlin.bintray.com/kotlinx"
-    }
+//    maven {
+//        url "https://kotlin.bintray.com/kotlinx"
+//    }
     maven {
         url "https://oss.sonatype.org/content/repositories/snapshots/"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,6 @@ sourceCompatibility = 1.8
 
 repositories {
     mavenCentral()
-//    maven {
-//        url "https://kotlin.bintray.com/kotlinx"
-//    }
     maven {
         url "https://oss.sonatype.org/content/repositories/snapshots/"
     }


### PR DESCRIPTION
Removed the bintray kotlinx maven repository entry (see e.g. https://github.com/Kotlin/kotlinx.html/issues/173) and thus, fixing the build mechanism again