### PR TITLE
Updating the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,10 @@ RUN cd /cottontail-src && \
 
 FROM zenika/kotlin:1.4.20-jdk11-slim
 
-RUN mkdir /cottontaildb-data
-COPY config.json /cottontaildb-data/
+RUN mkdir /cottontaildb-data /cottontaildb-config
+COPY config.json /cottontaildb-config/
 COPY --from=build /cottontail-src/cottontaildb-bin /
 
 EXPOSE 1865
 
-ENTRYPOINT /cottontaildb-bin/bin/cottontaildb /cottontaildb-data/config.json
+ENTRYPOINT /cottontaildb-bin/bin/cottontaildb /cottontaildb-config/config.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zenika/kotlin:1.4.20-jdk11 AS build
+FROM openjdk:latest AS build
 
 COPY . /cottontail-src
 RUN cd /cottontail-src && \
@@ -8,7 +8,7 @@ RUN cd /cottontail-src && \
   tar xf ../build/distributions/cottontaildb-bin.tar
 
 
-FROM zenika/kotlin:1.4.20-jdk11-slim
+FROM openjdk:latest
 
 RUN mkdir /cottontaildb-data /cottontaildb-config
 COPY config.json /cottontaildb-config/


### PR DESCRIPTION
Updating the Dockerfile to:
- Allow overriding of Cottontail DB data and config independently as most docker image use cases use default config.
- Update the base image to a much more recent and multi-platform openjdk image.