### PR TITLE
New default value for preview limit

### DIFF
--- a/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/query/PreviewEntityCommand.kt
+++ b/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/query/PreviewEntityCommand.kt
@@ -34,7 +34,7 @@ class PreviewEntityCommand(client: SimpleClient): AbstractCottontailCommand.Quer
     /**
      * Upper limit of results. Option given via CLI. Defaults to 50
      */
-    private val limit: Long by option("-l", "--limit", help = "Limits the amount of printed results").long().default(50).validate { require(it > 1) }
+    private val limit: Long by option("-l", "--limit", help = "Limits the amount of printed results").long().default(5).validate { require(it > 1) }
 
     /**
      * Offset from the start of the table. Option given vai CLI. Defaults to 0


### PR DESCRIPTION
Sensible value for preview command which enables normal terminal sizes to see schema in addition to example values. I think in most cases, you do not need to see 50 values to preview the content of an entity.