### PR TITLE
Fix/index delete

### DIFF
--- a/cottontaildb-dbms/src/testFixtures/kotlin/org/vitrivr/cottontail/test/GrpcTestUtils.kt
+++ b/cottontaildb-dbms/src/testFixtures/kotlin/org/vitrivr/cottontail/test/GrpcTestUtils.kt
@@ -5,9 +5,13 @@ import org.vitrivr.cottontail.client.SimpleClient
 import org.vitrivr.cottontail.client.language.basics.Type
 import org.vitrivr.cottontail.client.language.ddl.*
 import org.vitrivr.cottontail.client.language.dml.BatchInsert
+import org.vitrivr.cottontail.client.language.dml.Insert
 import org.vitrivr.cottontail.client.language.dql.Query
 import org.vitrivr.cottontail.core.database.Name
 import org.vitrivr.cottontail.grpc.CottontailGrpc
+import org.vitrivr.cottontail.test.TestConstants.DOUBLE_COLUMN_NAME
+import org.vitrivr.cottontail.test.TestConstants.INT_COLUMN_NAME
+import org.vitrivr.cottontail.test.TestConstants.STRING_COLUMN_NAME
 import kotlin.random.Random
 
 
@@ -43,9 +47,9 @@ object GrpcTestUtils {
      */
     fun createTestEntity(client: SimpleClient) {
         val create = CreateEntity(TestConstants.TEST_ENTITY_NAME.fqn)
-                .column(TestConstants.STRING_COLUMN_NAME, Type.STRING)
-                .column(TestConstants.INT_COLUMN_NAME, Type.INTEGER)
-                .column(TestConstants.DOUBLE_COLUMN_NAME, Type.DOUBLE)
+            .column(STRING_COLUMN_NAME, Type.STRING)
+            .column(INT_COLUMN_NAME, Type.INTEGER)
+            .column(DOUBLE_COLUMN_NAME, Type.DOUBLE)
         client.create(create)
     }
 
@@ -56,9 +60,9 @@ object GrpcTestUtils {
      */
     fun createTestVectorEntity(client: SimpleClient) {
         val create = CreateEntity(TestConstants.TEST_VECTOR_ENTITY_NAME.fqn)
-                .column(TestConstants.STRING_COLUMN_NAME, Type.STRING)
-                .column(TestConstants.INT_COLUMN_NAME, Type.INTEGER)
-                .column(TestConstants.TWOD_COLUMN_NAME, Type.FLOAT_VECTOR, 2)
+            .column(STRING_COLUMN_NAME, Type.STRING)
+            .column(INT_COLUMN_NAME, Type.INTEGER)
+            .column(TestConstants.TWOD_COLUMN_NAME, Type.FLOAT_VECTOR, 2)
         client.create(create)
     }
 
@@ -68,7 +72,7 @@ object GrpcTestUtils {
      * @param client [SimpleClient] to use.
      */
     fun populateTestEntity(client: SimpleClient) {
-        val batch = BatchInsert().into(TestConstants.TEST_ENTITY_NAME.fqn).columns(TestConstants.STRING_COLUMN_NAME, TestConstants.INT_COLUMN_NAME, TestConstants.DOUBLE_COLUMN_NAME)
+        val batch = BatchInsert().into(TestConstants.TEST_ENTITY_NAME.fqn).columns(STRING_COLUMN_NAME, INT_COLUMN_NAME, DOUBLE_COLUMN_NAME)
         val random = Random.Default
         repeat(TestConstants.TEST_COLLECTION_SIZE) {
             batch.append(
@@ -80,11 +84,16 @@ object GrpcTestUtils {
         client.insert(batch)
     }
 
+    fun insertIntoTestEntity(client: SimpleClient, string: String = RandomStringUtils.randomAlphabetic(5), int: Int = Random.nextInt(0, 100), double: Double = Random.nextDouble(1.0)) {
+        val insert = Insert().into(TestConstants.TEST_ENTITY_NAME.fqn).values(Pair(STRING_COLUMN_NAME, string), Pair(INT_COLUMN_NAME, int), Pair(DOUBLE_COLUMN_NAME, double))
+        client.insert(insert)
+    }
+
     /**
      * Creates a Lucene index on the [TestConstants.TEST_ENTITY_NAME].
      */
     fun createLuceneIndexOnTestEntity(client: SimpleClient) {
-        client.create(CreateIndex(TestConstants.TEST_ENTITY_NAME.fqn, TestConstants.STRING_COLUMN_NAME, CottontailGrpc.IndexType.LUCENE))
+        client.create(CreateIndex(TestConstants.TEST_ENTITY_NAME.fqn, STRING_COLUMN_NAME, CottontailGrpc.IndexType.LUCENE))
         client.optimize(OptimizeEntity(TestConstants.TEST_ENTITY_NAME.fqn))
     }
 
@@ -95,16 +104,16 @@ object GrpcTestUtils {
      */
     fun populateVectorEntity(client: SimpleClient) {
         val batch = BatchInsert().into(TestConstants.TEST_VECTOR_ENTITY_NAME.fqn)
-                .columns(TestConstants.STRING_COLUMN_NAME, TestConstants.INT_COLUMN_NAME, TestConstants.TWOD_COLUMN_NAME)
+            .columns(STRING_COLUMN_NAME, INT_COLUMN_NAME, TestConstants.TWOD_COLUMN_NAME)
         val random = Random.Default
         repeat(TestConstants.TEST_COLLECTION_SIZE) {
             val lat = random.nextFloat() + random.nextInt(0, 50)
             val lon = random.nextFloat() + random.nextInt(0, 50)
             val arr = floatArrayOf(lat, lon)
             batch.append(
-                    RandomStringUtils.randomAlphabetic(5),
-                    random.nextInt(0, 10),
-                    arr
+                RandomStringUtils.randomAlphabetic(5),
+                random.nextInt(0, 10),
+                arr
             )
         }
         client.insert(batch)


### PR DESCRIPTION
Inserting multiple entries with the same value on a column which is supposed to be unique causes strange behaviors (e.g. deletes do not work anymore).
This PR builds on #115 and adds a test to demonstrate the failing behavior. 