### PR TITLE
New CLI command for distinct queries

### DIFF
--- a/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/Cli.kt
+++ b/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/Cli.kt
@@ -19,10 +19,7 @@ import org.jline.reader.UserInterruptException
 import org.jline.reader.impl.completer.ArgumentCompleter
 import org.jline.terminal.TerminalBuilder
 import org.vitrivr.cottontail.cli.entity.*
-import org.vitrivr.cottontail.cli.query.CountEntityCommand
-import org.vitrivr.cottontail.cli.query.ExecuteQueryCommand
-import org.vitrivr.cottontail.cli.query.FindInEntityCommand
-import org.vitrivr.cottontail.cli.query.PreviewEntityCommand
+import org.vitrivr.cottontail.cli.query.*
 import org.vitrivr.cottontail.cli.schema.*
 import org.vitrivr.cottontail.cli.system.KillTransactionCommand
 import org.vitrivr.cottontail.cli.system.ListLocksCommand
@@ -315,7 +312,8 @@ class Cli(private val host: String = "localhost", private val port: Int = 1865) 
                     CountEntityCommand(this@Cli.client),
                     PreviewEntityCommand(this@Cli.client),
                     FindInEntityCommand(this@Cli.client),
-                    ExecuteQueryCommand(this@Cli.client)
+                    ExecuteQueryCommand(this@Cli.client),
+                    DistinctColumnQueryCommand(this@Cli.client)
                 ),
 
                 /* Transaction related commands. */

--- a/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/query/ExecuteQueryCommand.kt
+++ b/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/query/ExecuteQueryCommand.kt
@@ -17,7 +17,7 @@ import kotlin.time.ExperimentalTime
  * @version 2.0.0
  */
 @ExperimentalTime
-class ExecuteQueryCommand(client: SimpleClient): org.vitrivr.cottontail.cli.AbstractCottontailCommand.Query(client, name = "execute", help = "Counts the number of entries in the given entity. Usage: entity count <schema>.<entity>", expand = false) {
+class ExecuteQueryCommand(client: SimpleClient): org.vitrivr.cottontail.cli.AbstractCottontailCommand.Query(client, name = "execute", help = "Counts the number of entries in the given entity", expand = false) {
 
     /** Path to .proto file that contains query. */
     private val input: Path by option("-i", "--input", help = "Path to input .proto file that contains query.").convert { Paths.get(it) }.required()


### PR DESCRIPTION
This PR adds a CLI command which queries for distinct column values. It also unifies the (sometimes misleading) help prompts for CLI commands under `query`