### PR TITLE
Lucene & Special Characters

### DIFF
--- a/cottontaildb-dbms/src/test/kotlin/org/vitrivr/cottontail/dbms/queries/planning/planner/BTreeIndexSelectionPlannerTest.kt
+++ b/cottontaildb-dbms/src/test/kotlin/org/vitrivr/cottontail/dbms/queries/planning/planner/BTreeIndexSelectionPlannerTest.kt
@@ -96,7 +96,7 @@ class BTreeIndexSelectionPlannerTest : AbstractIndexTest() {
                 val bindings = this.columns.map { ctx.bindings.bind(it) to it }
 
                 /* Bind EQUALS operator. */
-                val op = ComparisonOperator.Binary.Equal(bindings[0].first, ctx.bindings.bind(this.inList[this.random.nextInt(0, this.inList.size - 1)]))
+                val op = ComparisonOperator.Binary.Equal(bindings[0].first, ctx.bindings.bind(this.inList[this.random.nextInt(this.inList.size - 1)]))
 
                 /* Prepare simple scan with projection. */
                 val scan0 = EntityScanLogicalOperatorNode(0, entityTx, bindings)
@@ -136,7 +136,7 @@ class BTreeIndexSelectionPlannerTest : AbstractIndexTest() {
             val bindings = this.columns.map { ctx.bindings.bind(it) to it }
 
             /* Bind EQUALS operator. */
-            val op = ComparisonOperator.Binary.Equal(bindings[0].first, ctx.bindings.bind(this.inList[this.random.nextInt(0, this.inList.size - 1)]))
+            val op = ComparisonOperator.Binary.Equal(bindings[0].first, ctx.bindings.bind(this.inList[this.random.nextInt(this.inList.size - 1)]))
 
             /* Prepare simple scan with projection. */
             val scan0 = EntityScanLogicalOperatorNode(0, entityTx, bindings)
@@ -274,9 +274,9 @@ class BTreeIndexSelectionPlannerTest : AbstractIndexTest() {
      * Generates and returns a new, random [StandaloneRecord] for inserting into the database.
      */
     override fun nextRecord(): StandaloneRecord {
-        val size = this.random.nextInt(10, 25)
+        val size = this.random.nextInt(15)+10
         val id = StringValueGenerator.random(size)
-        val value = LongValue(this.random.nextLong(-100000L, 10000L))
+        val value = LongValue(this.random.nextInt(110000)-100000L)
         if (this.inList.size < 50000 && this.random.nextFloat() <= 0.1f) {
             this.inList.add(id)
         }

--- a/cottontaildb-dbms/src/test/kotlin/org/vitrivr/cottontail/dbms/queries/planning/planner/UniqueBTreeIndexSelectionPlannerTest.kt
+++ b/cottontaildb-dbms/src/test/kotlin/org/vitrivr/cottontail/dbms/queries/planning/planner/UniqueBTreeIndexSelectionPlannerTest.kt
@@ -92,7 +92,7 @@ class UniqueBTreeIndexSelectionPlannerTest : AbstractIndexTest() {
                 val bindings = this.columns.map { ctx.bindings.bind(it) to it }
 
                 /* Bind EQUALS operator. */
-                val op = ComparisonOperator.Binary.Equal(bindings[0].first, ctx.bindings.bind(this.inList[this.random.nextInt(0, this.inList.size - 1)]))
+                val op = ComparisonOperator.Binary.Equal(bindings[0].first, ctx.bindings.bind(this.inList[this.random.nextInt(this.inList.size - 1)]))
 
                 /* Prepare simple scan with projection. */
                 val scan0 = EntityScanLogicalOperatorNode(0, entityTx, bindings)
@@ -132,7 +132,7 @@ class UniqueBTreeIndexSelectionPlannerTest : AbstractIndexTest() {
             val bindings = this.columns.map { ctx.bindings.bind(it) to it }
 
             /* Bind EQUALS operator. */
-            val op = ComparisonOperator.Binary.Equal(bindings[0].first, ctx.bindings.bind(this.inList[this.random.nextInt(0, this.inList.size - 1)]))
+            val op = ComparisonOperator.Binary.Equal(bindings[0].first, ctx.bindings.bind(this.inList[this.random.nextInt(this.inList.size - 1)]))
 
             /* Prepare simple scan with projection. */
             val scan0 = EntityScanLogicalOperatorNode(0, entityTx, bindings)
@@ -270,9 +270,9 @@ class UniqueBTreeIndexSelectionPlannerTest : AbstractIndexTest() {
      * Generates and returns a new, random [StandaloneRecord] for inserting into the database.
      */
     override fun nextRecord(): StandaloneRecord {
-        val size = this.random.nextInt(10, 25)
+        val size = this.random.nextInt(15)+10
         val id = StringValueGenerator.random(size)
-        val value = LongValue(this.random.nextLong(-100000L, 10000L))
+        val value = LongValue(this.random.nextInt(110000)-100000L)
         if (this.inList.size <= 50000 && this.random.nextBoolean()) {
             this.inList.add(id)
         }

--- a/cottontaildb-dbms/src/test/kotlin/org/vitrivr/cottontail/server/grpc/DQLServiceTest.kt
+++ b/cottontaildb-dbms/src/test/kotlin/org/vitrivr/cottontail/server/grpc/DQLServiceTest.kt
@@ -17,7 +17,10 @@ import org.vitrivr.cottontail.client.language.dql.Query
 import org.vitrivr.cottontail.embedded
 import org.vitrivr.cottontail.server.CottontailServer
 import org.vitrivr.cottontail.test.GrpcTestUtils
+import org.vitrivr.cottontail.test.GrpcTestUtils.createLuceneIndexOnTestEntity
 import org.vitrivr.cottontail.test.TestConstants
+import org.vitrivr.cottontail.test.TestConstants.DOUBLE_COLUMN_NAME
+import org.vitrivr.cottontail.test.TestConstants.INT_COLUMN_NAME
 import org.vitrivr.cottontail.test.TestConstants.STRING_COLUMN_NAME
 import org.vitrivr.cottontail.test.TestConstants.TEST_ENTITY_NAME
 import org.vitrivr.cottontail.test.TestConstants.TEST_VECTOR_ENTITY_NAME
@@ -118,11 +121,11 @@ class DQLServiceTest {
     @Test
     fun haversineDistance() {
         val query = Query()
-                .select("*")
-                .from(TEST_VECTOR_ENTITY_NAME.fqn)
-                .distance(TWOD_COLUMN_NAME, arrayOf(5f, 10f), Distances.HAVERSINE, "distance")
-                .order("distance", Direction.ASC)
-                .limit(500)
+            .select("*")
+            .from(TEST_VECTOR_ENTITY_NAME.fqn)
+            .distance(TWOD_COLUMN_NAME, arrayOf(5f, 10f), Distances.HAVERSINE, "distance")
+            .order("distance", Direction.ASC)
+            .limit(500)
         val result = client.query(query)
         val el = result.next()
         val distance = el.asDouble("distance")
@@ -132,12 +135,12 @@ class DQLServiceTest {
     @Test
     fun queryNNSWithLikeStart() {
         val query = Query()
-                .select("*")
-                .from(TEST_VECTOR_ENTITY_NAME.fqn)
-                .distance(TWOD_COLUMN_NAME, arrayOf(5f, 10f), Distances.L2, "distance")
-                .where(Expression(STRING_COLUMN_NAME, "LIKE", "a%"))
-                .order("distance", Direction.ASC)
-                .limit(500)
+            .select("*")
+            .from(TEST_VECTOR_ENTITY_NAME.fqn)
+            .distance(TWOD_COLUMN_NAME, arrayOf(5f, 10f), Distances.L2, "distance")
+            .where(Expression(STRING_COLUMN_NAME, "LIKE", "a%"))
+            .order("distance", Direction.ASC)
+            .limit(500)
 
         val result = client.query(query)
         for (r in result) {
@@ -151,11 +154,11 @@ class DQLServiceTest {
     @Test
     fun queryNNSWithLikeEnd() {
         val query = Query().from(TEST_VECTOR_ENTITY_NAME.fqn)
-                .select("*")
-                .distance(TWOD_COLUMN_NAME, arrayOf(5f, 10f), Distances.L2, "distance")
-                .where(Expression(STRING_COLUMN_NAME, "LIKE", "%z"))
-                .order("distance", Direction.ASC)
-                .limit(500)
+            .select("*")
+            .distance(TWOD_COLUMN_NAME, arrayOf(5f, 10f), Distances.L2, "distance")
+            .where(Expression(STRING_COLUMN_NAME, "LIKE", "%z"))
+            .order("distance", Direction.ASC)
+            .limit(500)
         val result = client.query(query)
         for (r in result) {
             val distance = r.asDouble("distance")
@@ -166,8 +169,36 @@ class DQLServiceTest {
     }
 
     @Test
+    fun luceneBasics(){
+        luceneInsertLookupTest("test", "test")
+    }
+
+    @Test
+    fun luceneNonAlphanumericCharacters() {
+        luceneInsertLookupTest("test-test", "-")
+    }
+
+    fun luceneInsertLookupTest(str: String, queryString: String){
+        val txId = this.client.begin()
+        val insert = Insert().into(TEST_ENTITY_NAME.fqn)
+            .value(STRING_COLUMN_NAME, str)
+            .value(INT_COLUMN_NAME, 1)
+            .value(DOUBLE_COLUMN_NAME, 1.0)
+            .txId(txId)
+        this.client.insert(insert)
+        this.client.commit(txId)
+        createLuceneIndexOnTestEntity(this.client)
+        val query = Query().from(TEST_ENTITY_NAME.fqn)
+            .select("*")
+            .fulltext(STRING_COLUMN_NAME, queryString, "distance")
+            .limit(1)
+        val result = client.query(query)
+        assert(result.hasNext())
+    }
+
+    @Test
     fun distinctLookup() {
-        val entryStrings = listOf("one", "ONE", "two", "three",)
+        val entryStrings = listOf("one", "ONE", "two", "three")
         testDistinct(entryStrings)
     }
 
@@ -177,7 +208,7 @@ class DQLServiceTest {
         testDistinct(entryStrings)
     }
 
-    private fun testDistinct(entryStrings: List<String>){
+    private fun testDistinct(entryStrings: List<String>) {
         /* Create entity with one column. */
         val entityName = TestConstants.TEST_SCHEMA.entity("distinct_test")
         this.client.create(CreateEntity(entityName.fqn).column(STRING_COLUMN_NAME, Type.STRING))
@@ -197,7 +228,7 @@ class DQLServiceTest {
             val query = Query().from(entityName.fqn).distinct(STRING_COLUMN_NAME, null)
             val result = this.client.query(query)
             val set = mutableSetOf<String>()
-            for(r in result){
+            for (r in result) {
                 val string = r.asString(STRING_COLUMN_NAME)!!
                 assertTrue(set.add(string), "$string was returned twice!")
             }


### PR DESCRIPTION
This PR adds some basics tests demonstrating (i) the current behavior of Lucene retrieval with special characters. The use case would be "-" in an OCR string.

There are open questions on if and how cottontail should expect those to be escaped, which i don't have particularly strong opinions on.

I think it would be helpful to have test which demonstrate and verify the kinds of input cottontail can handle, so feel free to change any of the tests.

Additionally, some of the random-generation code did not compile, so i adjusted the method calls to more basic, but equivalent ones.