### PR TITLE
Switch from deprecated openjdk to eclipse-temurin base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM openjdk:17 AS build
+FROM gradle:jdk17 AS build
 
 COPY . /cottontail-src
 WORKDIR /cottontail-src
-RUN ./gradlew distTar
+RUN gradle distTar
 WORKDIR /cottontail-src/cottontaildb-dbms/build/distributions/
 RUN tar xf ./cottontaildb-dbms.tar
 
-FROM openjdk:17
+FROM eclipse-temurin:17-jre
 
 RUN mkdir /cottontaildb-data /cottontaildb-config
 COPY config.json /cottontaildb-config/


### PR DESCRIPTION
See notice on https://hub.docker.com/_/openjdk

Alternatively you could also use the `gradle:jdk17` image to avoid downloading gradle on every build.

see also: https://github.com/vitrivr/cineast/pull/343