### PR TITLE
[Carrotli] Quality of Life Improvements

### DIFF
--- a/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/entity/ClearEntityCommand.kt
+++ b/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/entity/ClearEntityCommand.kt
@@ -17,7 +17,7 @@ import kotlin.time.measureTimedValue
 @ExperimentalTime
 class ClearEntityCommand(client: SimpleClient) : AbstractCottontailCommand.Entity(client, name = "clear", help = "Clears the given entity, i.e., deletes all data it contains. Usage: entity clear <schema>.<entity>") {
     override fun exec() {
-        if (TermUi.confirm("Do you really want to delete all data from entity ${this.entityName} (y/N)?", default = false, showDefault = false) == true) {
+        if (confirm("Do you really want to delete all data from entity ${this.entityName} (y/N)?", default = false, showDefault = false) == true) {
             val time = measureTimedValue {
                 this.client.delete(Delete(this.entityName.toString()))
             }

--- a/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/entity/CreateEntityCommand.kt
+++ b/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/entity/CreateEntityCommand.kt
@@ -81,7 +81,7 @@ class CreateEntityCommand(client: SimpleClient) : AbstractCottontailCommand.Enti
                 }
 
                 /* Ask if anther column should be added. */
-                if (colDef.columnsCount > 0 && TermUi.confirm("Do you want to add another column (size = ${colDef.columnsCount})?") == false) {
+                if (colDef.columnsCount > 0 && confirm("Do you want to add another column (size = ${colDef.columnsCount})?") == false) {
                     break
                 }
             } while (true)
@@ -115,7 +115,7 @@ class CreateEntityCommand(client: SimpleClient) : AbstractCottontailCommand.Enti
             }
 
             /* As for final confirmation and create entity. */
-            if (TermUi.confirm(text = "Please confirm that you want to create the entity:\n$tbl", default = true) == true) {
+            if (confirm(text = "Please confirm that you want to create the entity:\n$tbl", default = true) == true) {
                 val time = measureTimedValue {
                     TabulationUtilities.tabulate(this.client.create(CottontailGrpc.CreateEntityMessage.newBuilder().setDefinition(colDef).build()))
                 }
@@ -158,8 +158,8 @@ class CreateEntityCommand(client: SimpleClient) : AbstractCottontailCommand.Enti
      */
     private fun promptForColumn(): CottontailGrpc.ColumnDefinition? {
         val def = CottontailGrpc.ColumnDefinition.newBuilder()
-        def.nameBuilder.name = TermUi.prompt("Column name (must consist of letters and numbers)")
-        def.type = TermUi.prompt("Column type (${CottontailGrpc.Type.values().joinToString(", ")})") {
+        def.nameBuilder.name = prompt("Column name (must consist of letters and numbers)")
+        def.type = prompt("Column type (${CottontailGrpc.Type.values().joinToString(", ")})") {
             CottontailGrpc.Type.valueOf(it.uppercase())
         }
         def.length = when (def.type) {
@@ -169,10 +169,10 @@ class CreateEntityCommand(client: SimpleClient) : AbstractCottontailCommand.Enti
             CottontailGrpc.Type.INT_VEC,
             CottontailGrpc.Type.BOOL_VEC,
             CottontailGrpc.Type.COMPLEX32_VEC,
-            CottontailGrpc.Type.COMPLEX64_VEC -> TermUi.prompt("\rColumn lengths (i.e. number of entries for vectors)") { it.toInt() } ?: 1
+            CottontailGrpc.Type.COMPLEX64_VEC -> prompt("\rColumn lengths (i.e. number of entries for vectors)") { it.toInt() } ?: 1
             else -> -1
         }
-        def.nullable = TermUi.confirm(text = "Should column be nullable?", default = false) ?: false
+        def.nullable = confirm(text = "Should column be nullable?", default = false) ?: false
 
         val tbl = table {
             cellStyle {
@@ -192,7 +192,7 @@ class CreateEntityCommand(client: SimpleClient) : AbstractCottontailCommand.Enti
             }
         }
 
-        return if (TermUi.confirm("Please confirm column:\n$tbl") == true) {
+        return if (confirm("Please confirm column:\n$tbl") == true) {
             def.build()
         } else {
             null

--- a/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/entity/DeleteRowCommand.kt
+++ b/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/entity/DeleteRowCommand.kt
@@ -32,7 +32,7 @@ class DeleteRowCommand(client: SimpleClient) : AbstractCottontailCommand.Entity(
     val value: String by option("-v", "--value", help = "The value").required()
 
     override fun exec() {
-        if (this.confirm || TermUi.confirm("Do you really want to delete the rows from ${this.entityName} where where $col = $value [y/N]?", default = false, showDefault = false) == true) {
+        if (this.confirm || confirm("Do you really want to delete the rows from ${this.entityName} where where $col = $value [y/N]?", default = false, showDefault = false) == true) {
             try {
                 val timedTable = measureTimedValue {
                     TabulationUtilities.tabulate(this.client.delete(Delete().from(entityName.fqn).where(Expression(this.col, "=", this.value))))

--- a/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/entity/DropEntityCommand.kt
+++ b/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/entity/DropEntityCommand.kt
@@ -28,7 +28,7 @@ class DropEntityCommand(client: SimpleClient) : AbstractCottontailCommand.Entity
     ).flag()
 
     override fun exec() {
-        if (this.confirm || TermUi.confirm("Do you really want to drop the entity ${this.entityName} [y/N]?", default = false, showDefault = false) == true) {
+        if (this.confirm || confirm("Do you really want to drop the entity ${this.entityName} [y/N]?", default = false, showDefault = false) == true) {
             try {
                 val timedTable = measureTimedValue {
                     TabulationUtilities.tabulate(this.client.drop(DropEntity(this.entityName.toString())))

--- a/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/entity/DropIndexCommand.kt
+++ b/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/entity/DropIndexCommand.kt
@@ -37,7 +37,7 @@ class DropIndexCommand(client: SimpleClient) : AbstractCottontailCommand.Entity(
     ).flag()
 
     override fun exec() {
-        if (this.confirm || TermUi.confirm("Do you really want to drop the index ${this.indexName} [y/N]?", default = false, showDefault = false) == true) {
+        if (this.confirm || confirm("Do you really want to drop the index ${this.indexName} [y/N]?", default = false, showDefault = false) == true) {
             try {
                 val timedTable = measureTimedValue {
                     TabulationUtilities.tabulate(this.client.drop(DropIndex(this.indexName.toString())))

--- a/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/entity/ImportDataCommand.kt
+++ b/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/entity/ImportDataCommand.kt
@@ -155,10 +155,10 @@ class ImportDataCommand(client: SimpleClient) : AbstractCottontailCommand.Entity
     private val singleTransaction: Boolean by option("-t", "--transaction", help="Flag indicating, whether the import should be executed in a single transaction or not.").flag()
 
     /** Flag indicating, whether the import should be fuzzy: Ignore corrupt entries and just continue */
-    private val fuzzy: Boolean by option("--fuzzy", help="Flag indicating, whether the import should be fuzzy: Ignore corrupt entries and just continue").flag()
+    private val bestEffort: Boolean by option("--best-effort", help="Flag indicating, whether the import should be best effort: Ignore corrupt entries and just continue").flag()
 
     /**
      * Executes this [ImportDataCommand].
      */
-    override fun exec() = importData(this.entityName, this.input, this.format, this.client, this.singleTransaction, this.fuzzy)
+    override fun exec() = importData(this.entityName, this.input, this.format, this.client, this.singleTransaction, this.bestEffort)
 }

--- a/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/entity/ImportDataCommand.kt
+++ b/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/entity/ImportDataCommand.kt
@@ -154,7 +154,7 @@ class ImportDataCommand(client: SimpleClient) : AbstractCottontailCommand.Entity
     private val singleTransaction: Boolean by option("-t", "--transaction", help="Flag indicating, whether the import should be executed in a single transaction or not.").flag()
 
     /** Flag indicating, whether the import should be fuzzy: Ignore corrupt entries and just continue */
-    private val fuzzy: Boolean by option("-f", "--fuzzy", help="Flag indicating, whether the import should be fuzzy: Ignore corrupt entries and just continue").flag()
+    private val fuzzy: Boolean by option("--fuzzy", help="Flag indicating, whether the import should be fuzzy: Ignore corrupt entries and just continue").flag()
 
     /**
      * Executes this [ImportDataCommand].

--- a/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/entity/ImportDataCommand.kt
+++ b/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/entity/ImportDataCommand.kt
@@ -1,9 +1,6 @@
 package org.vitrivr.cottontail.cli.entity
 
-import com.github.ajalt.clikt.parameters.options.convert
-import com.github.ajalt.clikt.parameters.options.flag
-import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.enum
 import org.vitrivr.cottontail.cli.AbstractCottontailCommand
 import org.vitrivr.cottontail.client.SimpleClient
@@ -42,10 +39,10 @@ class ImportDataCommand(client: SimpleClient) : AbstractCottontailCommand.Entity
          * @param client The [SimpleClient] to use.
          * @param singleTransaction Flag indicating whether import should happen in a single transaction.
          */
-        fun importData(entityName: Name.EntityName, input: Path, format: Format, client: SimpleClient, singleTransaction: Boolean) {
+        fun importData(entityName: Name.EntityName, input: Path, format: Format, client: SimpleClient, singleTransaction: Boolean, fuzzy: Boolean) {
             /* Read schema and prepare Iterator. */
             val schema = readSchema(entityName, client)
-            val iterator = format.newImporter(input, schema)
+            val iterator = format.newImporter(input, schema, fuzzy)
 
             /** Begin transaction (if single transaction option has been set). */
             val txId = if (singleTransaction) {
@@ -154,10 +151,13 @@ class ImportDataCommand(client: SimpleClient) : AbstractCottontailCommand.Entity
     ).convert { Paths.get(it) }.required()
 
     /** Flag indicating, whether the import should be executed in a single transaction or not. */
-    private val singleTransaction: Boolean by option("-t", "--transaction").flag()
+    private val singleTransaction: Boolean by option("-t", "--transaction", help="Flag indicating, whether the import should be executed in a single transaction or not.").flag()
+
+    /** Flag indicating, whether the import should be fuzzy: Ignore corrupt entries and just continue */
+    private val fuzzy: Boolean by option("-f", "--fuzzy", help="Flag indicating, whether the import should be fuzzy: Ignore corrupt entries and just continue").flag()
 
     /**
      * Executes this [ImportDataCommand].
      */
-    override fun exec() = importData(this.entityName, this.input, this.format, this.client, this.singleTransaction)
+    override fun exec() = importData(this.entityName, this.input, this.format, this.client, this.singleTransaction, this.fuzzy)
 }

--- a/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/entity/ImportDataCommand.kt
+++ b/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/entity/ImportDataCommand.kt
@@ -38,11 +38,12 @@ class ImportDataCommand(client: SimpleClient) : AbstractCottontailCommand.Entity
          * @param format The [Format] of the data to import.
          * @param client The [SimpleClient] to use.
          * @param singleTransaction Flag indicating whether import should happen in a single transaction.
+         * @param bestEffort Whether to import "best effort": CSV import is capable of e.g. ignoring broken rows which this flag enables
          */
-        fun importData(entityName: Name.EntityName, input: Path, format: Format, client: SimpleClient, singleTransaction: Boolean, fuzzy: Boolean) {
+        fun importData(entityName: Name.EntityName, input: Path, format: Format, client: SimpleClient, singleTransaction: Boolean, bestEffort: Boolean) {
             /* Read schema and prepare Iterator. */
             val schema = readSchema(entityName, client)
-            val iterator = format.newImporter(input, schema, fuzzy)
+            val iterator = format.newImporter(input, schema, bestEffort)
 
             /** Begin transaction (if single transaction option has been set). */
             val txId = if (singleTransaction) {

--- a/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/entity/TruncateEntityCommand.kt
+++ b/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/entity/TruncateEntityCommand.kt
@@ -1,6 +1,6 @@
 package org.vitrivr.cottontail.cli.entity
 
-import com.github.ajalt.clikt.output.TermUi
+import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import io.grpc.StatusException
@@ -30,7 +30,7 @@ class TruncateEntityCommand(client: SimpleClient) : AbstractCottontailCommand.En
          * @param confirm Flag indicating whether confirmation is already given (CLI only, not testable).
          */
         fun truncate(entityName: Name.EntityName, client: SimpleClient, confirm: Boolean) {
-            if (confirm || TermUi.confirm("Do you really want to truncate the entity $entityName [y/N]?", default = false, showDefault = false) == true) {
+            if (confirm) {
                 try {
                     val timedTable = measureTimedValue {
                         TabulationUtilities.tabulate(client.truncate(TruncateEntity(entityName.toString())))
@@ -53,5 +53,5 @@ class TruncateEntityCommand(client: SimpleClient) : AbstractCottontailCommand.En
         help = "Directly provides the confirmation option. Set to true, no interactive prompt is given"
     ).flag()
 
-    override fun exec() = truncate(this.entityName, this.client, this.confirm)
+    override fun exec() = truncate(this.entityName, this.client, this.confirm || confirm("Do you really want to truncate the entity $entityName [y/N]?", default = false, showDefault = false) == true)
 }

--- a/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/query/PreviewEntityCommand.kt
+++ b/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/query/PreviewEntityCommand.kt
@@ -37,7 +37,7 @@ class PreviewEntityCommand(client: SimpleClient): AbstractCottontailCommand.Quer
     /**
      * Upper limit of results. Option given via CLI. Defaults to 50
      */
-    private val limit: Long by option("-l", "--limit", help = "Limits the amount of printed results").long().default(5).validate { require(it > 1) }
+    private val limit: Long by option("-l", "--limit", help = "Limits the amount of printed results").long().default(5).validate { require(it >= 1) }
 
     /**
      * Offset from the start of the table. Option given vai CLI. Defaults to 0

--- a/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/schema/DropSchemaCommand.kt
+++ b/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/cli/schema/DropSchemaCommand.kt
@@ -27,7 +27,7 @@ class DropSchemaCommand(client: SimpleClient) : AbstractCottontailCommand.Schema
 
 
     override fun exec() {
-        if (this.confirm || TermUi.confirm(
+        if (this.confirm || confirm(
                 "Do you really want to drop the schema ${this.schemaName} [y/N]?",
                 default = false,
                 showDefault = false

--- a/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/data/Format.kt
+++ b/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/data/Format.kt
@@ -32,12 +32,13 @@ enum class Format(val suffix: String) {
      *
      * @param file [Path] to input file.
      * @param schema Optional list of [ColumnDef]s that should be imported (not required).
+     * @param fuzzy Optional flag to use fuzzy import (e.g. try best effort and skip corrupt entries)
      * @return [DataImporter]
      */
-    fun newImporter(file: Path, schema: List<ColumnDef<*>>): DataImporter = when (this) {
+    fun newImporter(file: Path, schema: List<ColumnDef<*>>, fuzzy:Boolean=false): DataImporter = when (this) {
         PROTO -> ProtoDataImporter(file, schema)
         JSON -> JsonDataImporter(file, schema)
-        CSV -> CSVDataImporter(file, schema)
+        CSV -> CSVDataImporter(file, schema, fuzzy)
     }
 
     /**

--- a/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/data/exporter/CSVDataExporter.kt
+++ b/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/data/exporter/CSVDataExporter.kt
@@ -26,7 +26,7 @@ class CSVDataExporter(override val path: Path) : DataExporter {
 
     override fun offer(tuple: Tuple) {
         if (header == null) {
-            header = (0..tuple.size()).map { tuple.nameForIndex(it) }
+            header = (0 until tuple.size()).map { tuple.nameForIndex(it) }
             writer.writeRow(header)
         }
         val row = header!!.map { colName ->

--- a/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/data/exporter/JsonDataExporter.kt
+++ b/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/data/exporter/JsonDataExporter.kt
@@ -15,7 +15,7 @@ import java.nio.file.StandardOpenOption
  * Data produced by the [JsonDataExporter] can be used as input for the [JsonDataImporter].
  *
  * @author Ralph Gasser
- * @version 1.1.0
+ * @version 1.1.1
  */
 class JsonDataExporter(override val path: Path, val indent: String = "") : DataExporter {
     /** The [Format] handled by this [DataExporter]. */
@@ -44,7 +44,7 @@ class JsonDataExporter(override val path: Path, val indent: String = "") : DataE
     override fun offer(tuple: Tuple) {
         this.writer.beginObject()
         repeat(tuple.size()) {
-            this.writer.name(tuple.nameForIndex(it))
+            this.writer.name(tuple.nameForIndex(it).split('.').last())
             when(tuple.type(it)) {
                 Type.BOOLEAN -> this.writer.value(tuple.asBoolean(it))
                 Type.BYTE -> this.writer.value(tuple.asByte(it))

--- a/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/data/exporter/JsonDataExporter.kt
+++ b/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/data/exporter/JsonDataExporter.kt
@@ -17,7 +17,7 @@ import java.nio.file.StandardOpenOption
  * @author Ralph Gasser
  * @version 1.1.1
  */
-class JsonDataExporter(override val path: Path, val indent: String = "") : DataExporter {
+class JsonDataExporter(override val path: Path, val indent: String = "", val simpleNames: Boolean = true) : DataExporter {
     /** The [Format] handled by this [DataExporter]. */
     override val format: Format = Format.JSON
 
@@ -44,7 +44,11 @@ class JsonDataExporter(override val path: Path, val indent: String = "") : DataE
     override fun offer(tuple: Tuple) {
         this.writer.beginObject()
         repeat(tuple.size()) {
-            this.writer.name(tuple.nameForIndex(it).split('.').last())
+            if (this.simpleNames) {
+                this.writer.name(tuple.nameForIndex(it).split('.').last())
+            } else {
+                this.writer.name(tuple.nameForIndex(it))
+            }
             when(tuple.type(it)) {
                 Type.BOOLEAN -> this.writer.value(tuple.asBoolean(it))
                 Type.BYTE -> this.writer.value(tuple.asByte(it))

--- a/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/data/importer/CSVDataImporter.kt
+++ b/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/data/importer/CSVDataImporter.kt
@@ -1,5 +1,7 @@
 package org.vitrivr.cottontail.data.importer
 
+import com.github.doyaaaaaken.kotlincsv.dsl.context.ExcessFieldsRowBehaviour
+import com.github.doyaaaaaken.kotlincsv.dsl.context.InsufficientFieldsRowBehaviour
 import com.github.doyaaaaaken.kotlincsv.dsl.csvReader
 import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap
 import org.vitrivr.cottontail.core.database.ColumnDef
@@ -9,9 +11,14 @@ import org.vitrivr.cottontail.core.values.types.Value
 import org.vitrivr.cottontail.data.Format
 import java.nio.file.Path
 
-class CSVDataImporter(override val path: Path, override val schema: List<ColumnDef<*>>) : DataImporter {
+class CSVDataImporter(override val path: Path, override val schema: List<ColumnDef<*>>, private val fuzzy: Boolean = false) : DataImporter {
 
-    private val rows = csvReader().readAllWithHeader(path.toFile())
+    private val rows = csvReader{
+        skipEmptyLine= fuzzy // if fuzzyness is enabled, skip empty lines silently
+        excessFieldsRowBehaviour= fuzzy.let { if(it){ExcessFieldsRowBehaviour.TRIM}else{ExcessFieldsRowBehaviour.ERROR} }
+        insufficientFieldsRowBehaviour= fuzzy.let { if(it){InsufficientFieldsRowBehaviour.IGNORE}else{InsufficientFieldsRowBehaviour.ERROR} }
+    }
+    .readAllWithHeader(path.toFile())
     private var rowIndex = 0
 
     /** The [Format] handled by this [DataImporter]. */

--- a/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/data/importer/CSVDataImporter.kt
+++ b/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/data/importer/CSVDataImporter.kt
@@ -14,20 +14,20 @@ import java.nio.file.Path
 class CSVDataImporter(
     override val path: Path,
     override val schema: List<ColumnDef<*>>,
-    private val fuzzy: Boolean = false
+    private val bestEffort: Boolean = false
 ) : DataImporter {
 
     private val rows = csvReader {
-        /** Fuzziness enabled: Skip empty lines */
-        skipEmptyLine = fuzzy
-        /** Fuzziness enabled: trim excess fields */
-        excessFieldsRowBehaviour = if (fuzzy) {
+        /** Best Effort enabled: Skip empty lines */
+        skipEmptyLine = bestEffort
+        /** Best Effort enabled: trim excess fields */
+        excessFieldsRowBehaviour = if (bestEffort) {
             ExcessFieldsRowBehaviour.TRIM
         } else {
             ExcessFieldsRowBehaviour.ERROR
         }
-        /** Fuzziness enabled: ignore (=skip) insufficiently filled lines */
-        insufficientFieldsRowBehaviour = if (fuzzy) {
+        /** Best Effort enabled: ignore (=skip) insufficiently filled lines */
+        insufficientFieldsRowBehaviour = if (bestEffort) {
             InsufficientFieldsRowBehaviour.IGNORE
         } else {
             InsufficientFieldsRowBehaviour.ERROR

--- a/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/data/importer/JsonDataImporter.kt
+++ b/cottontaildb-cli/src/main/kotlin/org/vitrivr/cottontail/data/importer/JsonDataImporter.kt
@@ -6,7 +6,6 @@ import com.google.gson.stream.JsonToken
 import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap
 import org.vitrivr.cottontail.client.iterators.Tuple
 import org.vitrivr.cottontail.core.database.ColumnDef
-import org.vitrivr.cottontail.core.database.Name
 import org.vitrivr.cottontail.core.values.*
 import org.vitrivr.cottontail.core.values.types.Types
 import org.vitrivr.cottontail.core.values.types.Value
@@ -20,7 +19,7 @@ import java.nio.file.Path
  * fields must occur in order of definition.
  *
  * @author Ralph Gasser
- * @version 1.1.0
+ * @version 1.1.1
  */
 class JsonDataImporter(override val path: Path, override val schema: List<ColumnDef<*>>) : DataImporter {
 
@@ -52,9 +51,8 @@ class JsonDataImporter(override val path: Path, override val schema: List<Column
         this.reader.beginObject()
         val value = Object2ObjectArrayMap<ColumnDef<*>, Value?>(this.schema.size)
         for (column in this.schema) {
-            val parsed = this.reader.nextName().split('.')
-            val name = Name.ColumnName.create(parsed[0], parsed[1], parsed[2])
-            check(name == column.name) { "$name does not match the expected column name ${column.name}." }
+            val name = this.reader.nextName().split('.').last()
+            check(name == column.name.column) { "$name does not match the expected column name ${column.name}." }
             value[column] = when (column.type) {
                 is Types.Boolean -> BooleanValue(this.reader.nextBoolean())
                 is Types.Byte -> ByteValue(this.reader.nextInt())

--- a/cottontaildb-cli/src/test/kotlin/org/vitrivr/cottontail/cli/ExportImportCommandTest.kt
+++ b/cottontaildb-cli/src/test/kotlin/org/vitrivr/cottontail/cli/ExportImportCommandTest.kt
@@ -58,7 +58,7 @@ class ExportImportCommandTest : AbstractClientTest() {
                 val exportFile = exportFile(format, entityName)
                 val count = countElements(this.client, entityName)
                 TruncateEntityCommand.truncate(entityName, this.client, true)
-                ImportDataCommand.importData(entityName, exportFile, format, this.client, true, fuzzy = false)
+                ImportDataCommand.importData(entityName, exportFile, format, this.client, true, bestEffort = false)
                 assert(count == countElements(this.client, entityName))
             }
         }
@@ -73,7 +73,7 @@ class ExportImportCommandTest : AbstractClientTest() {
             val exportFile = exportFile(format, TEST_ENTITY_NAME)
             val count = countElements(this.client, TEST_ENTITY_NAME)
             TruncateEntityCommand.truncate(TEST_ENTITY_NAME, this.client, true)
-            ImportDataCommand.importData(TEST_ENTITY_NAME, exportFile, format, this.client, true, fuzzy=false)
+            ImportDataCommand.importData(TEST_ENTITY_NAME, exportFile, format, this.client, true, bestEffort=false)
             assert(count == countElements(this.client, TEST_ENTITY_NAME))
         }
     }

--- a/cottontaildb-cli/src/test/kotlin/org/vitrivr/cottontail/cli/ExportImportCommandTest.kt
+++ b/cottontaildb-cli/src/test/kotlin/org/vitrivr/cottontail/cli/ExportImportCommandTest.kt
@@ -58,7 +58,7 @@ class ExportImportCommandTest : AbstractClientTest() {
                 val exportFile = exportFile(format, entityName)
                 val count = countElements(this.client, entityName)
                 TruncateEntityCommand.truncate(entityName, this.client, true)
-                ImportDataCommand.importData(entityName, exportFile, format, this.client, true)
+                ImportDataCommand.importData(entityName, exportFile, format, this.client, true, fuzzy = false)
                 assert(count == countElements(this.client, entityName))
             }
         }
@@ -73,7 +73,7 @@ class ExportImportCommandTest : AbstractClientTest() {
             val exportFile = exportFile(format, TEST_ENTITY_NAME)
             val count = countElements(this.client, TEST_ENTITY_NAME)
             TruncateEntityCommand.truncate(TEST_ENTITY_NAME, this.client, true)
-            ImportDataCommand.importData(TEST_ENTITY_NAME, exportFile, format, this.client, true)
+            ImportDataCommand.importData(TEST_ENTITY_NAME, exportFile, format, this.client, true, fuzzy=false)
             assert(count == countElements(this.client, TEST_ENTITY_NAME))
         }
     }


### PR DESCRIPTION
Adding some quality of life improvements in c(arrot)li:

- [x] Enabling fuzzy import for CSV import (i.e. omit broken lines, ignore too many columns), disabled by default
- [x] Re-adding typeahead autocompletion for schemata and entities _Note: This does not yet include options completion_
- [x] Adding `export` alias for `dump` commands (schema and enttity) 
- [x] Import / Export for JSON format: toggleable simple name for columns (by @ppanopticon )
- [x] Fix CSV exporter, as it currently throws an index out of bounds

Also includes minor documentation and deprecation updates