### PR TITLE
add neccessary `import` statements in the testing code to build successfully

### DIFF
--- a/cottontaildb-dbms/src/test/kotlin/org/vitrivr/cottontail/dbms/queries/planning/planner/BTreeIndexSelectionPlannerTest.kt
+++ b/cottontaildb-dbms/src/test/kotlin/org/vitrivr/cottontail/dbms/queries/planning/planner/BTreeIndexSelectionPlannerTest.kt
@@ -31,6 +31,8 @@ import org.vitrivr.cottontail.dbms.queries.planning.rules.physical.index.NNSInde
 import org.vitrivr.cottontail.dbms.queries.planning.rules.physical.merge.LimitingSortMergeRule
 import org.vitrivr.cottontail.dbms.queries.planning.rules.physical.pushdown.CountPushdownRule
 import org.vitrivr.cottontail.dbms.schema.SchemaTx
+import org.vitrivr.cottontail.utilities.math.random.nextInt
+import org.vitrivr.cottontail.utilities.math.random.nextLong
 
 /**
  * A collection of test cases that test the outcome for index selection in presence of an [IndexType.BTREE].

--- a/cottontaildb-dbms/src/test/kotlin/org/vitrivr/cottontail/dbms/queries/planning/planner/UniqueBTreeIndexSelectionPlannerTest.kt
+++ b/cottontaildb-dbms/src/test/kotlin/org/vitrivr/cottontail/dbms/queries/planning/planner/UniqueBTreeIndexSelectionPlannerTest.kt
@@ -35,7 +35,7 @@ import org.vitrivr.cottontail.utilities.math.random.nextInt
 import org.vitrivr.cottontail.utilities.math.random.nextLong
 
 /**
- * A collection of test cases that test the outcome for index selection in presend of an [IndexType.BTREE_UQ].
+ * A collection of test cases that test the outcome for index selection in presence of an [IndexType.BTREE_UQ].
  *
  * @author Ralph Gasser
  * @version 1.0.0

--- a/cottontaildb-dbms/src/test/kotlin/org/vitrivr/cottontail/dbms/queries/planning/planner/UniqueBTreeIndexSelectionPlannerTest.kt
+++ b/cottontaildb-dbms/src/test/kotlin/org/vitrivr/cottontail/dbms/queries/planning/planner/UniqueBTreeIndexSelectionPlannerTest.kt
@@ -31,6 +31,8 @@ import org.vitrivr.cottontail.dbms.queries.planning.rules.physical.index.NNSInde
 import org.vitrivr.cottontail.dbms.queries.planning.rules.physical.merge.LimitingSortMergeRule
 import org.vitrivr.cottontail.dbms.queries.planning.rules.physical.pushdown.CountPushdownRule
 import org.vitrivr.cottontail.dbms.schema.SchemaTx
+import org.vitrivr.cottontail.utilities.math.random.nextInt
+import org.vitrivr.cottontail.utilities.math.random.nextLong
 
 /**
  * A collection of test cases that test the outcome for index selection in presend of an [IndexType.BTREE_UQ].


### PR DESCRIPTION
thanks for making this project open source.

I was trying to build this project locally but faced to building errors in the task `:cottontaildb-dbms:test`.
it seems that we need to import `nextLong` and `nextInt`  in both `BTreeIndexSelectionPlannerTest.kt` and `UniqueBTreeIndexSelectionPlannerTest.kt` .

so here I proposed this PR to make up these two imports and fix one typo.