### PR TITLE
Implementing order-only on UnaryPhysicalOperatorNode

### DIFF
--- a/cottontaildb-dbms/src/main/kotlin/org/vitrivr/cottontail/dbms/queries/operators/physical/UnaryPhysicalOperatorNode.kt
+++ b/cottontaildb-dbms/src/main/kotlin/org/vitrivr/cottontail/dbms/queries/operators/physical/UnaryPhysicalOperatorNode.kt
@@ -10,6 +10,7 @@ import org.vitrivr.cottontail.dbms.queries.operators.OperatorNode
 import org.vitrivr.cottontail.dbms.queries.operators.logical.UnaryLogicalOperatorNode
 import org.vitrivr.cottontail.dbms.queries.operators.physical.merge.MergeLimitingSortPhysicalOperatorNode
 import org.vitrivr.cottontail.dbms.queries.operators.physical.merge.MergePhysicalOperatorNode
+import org.vitrivr.cottontail.dbms.queries.operators.physical.sort.SortPhysicalOperatorNode
 import org.vitrivr.cottontail.dbms.queries.operators.physical.transform.LimitPhysicalOperatorNode
 import org.vitrivr.cottontail.dbms.statistics.columns.ValueStatistics
 import java.io.PrintStream
@@ -168,7 +169,10 @@ abstract class UnaryPhysicalOperatorNode(input: Physical? = null) : OperatorNode
                     val limit = input[LimitTrait]!!
                     this.copyWithOutput(MergeLimitingSortPhysicalOperatorNode(*inbound.toTypedArray(), sortOn = order.order, limit = limit.limit))
                 }
-                input.hasTrait(OrderTrait) -> TODO()
+                input.hasTrait(OrderTrait) -> {
+                    val order = input[OrderTrait]!!
+                    this.copyWithOutput(SortPhysicalOperatorNode(MergePhysicalOperatorNode(*inbound.toTypedArray()), sortOn = order.order))
+                }
                 input.hasTrait(LimitTrait) -> {
                     val limit = input[LimitTrait]!!
                     this.copyWithOutput(LimitPhysicalOperatorNode(MergePhysicalOperatorNode(*inbound.toTypedArray()), limit = limit.limit))

--- a/cottontaildb-dbms/src/main/kotlin/org/vitrivr/cottontail/server/grpc/services/TransactionalGrpcService.kt
+++ b/cottontaildb-dbms/src/main/kotlin/org/vitrivr/cottontail/server/grpc/services/TransactionalGrpcService.kt
@@ -168,6 +168,7 @@ internal interface TransactionalGrpcService {
             }
         } catch (e: Throwable) {
             LOGGER.error("[${context.txn.txId}, ${context.queryId}] Preparation of query failed: ${e.message}")
+            e.printStackTrace()
             if (context.txn.type.autoRollback) context.txn.rollback() /* Handle auto-rollback. */
             return flow { throw context.toStatusException(e, false) }
         }

--- a/cottontaildb-dbms/src/main/kotlin/org/vitrivr/cottontail/server/grpc/services/TransactionalGrpcService.kt
+++ b/cottontaildb-dbms/src/main/kotlin/org/vitrivr/cottontail/server/grpc/services/TransactionalGrpcService.kt
@@ -7,6 +7,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.transform
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder
+import org.apache.commons.lang3.builder.ToStringStyle
 import org.slf4j.LoggerFactory
 import org.vitrivr.cottontail.client.language.basics.Constants
 import org.vitrivr.cottontail.core.basics.Record
@@ -167,7 +169,7 @@ internal interface TransactionalGrpcService {
                 }
             }
         } catch (e: Throwable) {
-            LOGGER.error("[${context.txn.txId}, ${context.queryId}] Preparation of query $context failed: ${e.message}")
+            LOGGER.error("[${context.txn.txId}, ${context.queryId}] Preparation of query ${ReflectionToStringBuilder.toString(context, ToStringStyle.JSON_STYLE)} failed: ${e.message}")
             e.printStackTrace()
             if (context.txn.type.autoRollback) context.txn.rollback() /* Handle auto-rollback. */
             return flow { throw context.toStatusException(e, false) }

--- a/cottontaildb-dbms/src/main/kotlin/org/vitrivr/cottontail/server/grpc/services/TransactionalGrpcService.kt
+++ b/cottontaildb-dbms/src/main/kotlin/org/vitrivr/cottontail/server/grpc/services/TransactionalGrpcService.kt
@@ -167,7 +167,7 @@ internal interface TransactionalGrpcService {
                 }
             }
         } catch (e: Throwable) {
-            LOGGER.error("[${context.txn.txId}, ${context.queryId}] Preparation of query failed: ${e.message}")
+            LOGGER.error("[${context.txn.txId}, ${context.queryId}] Preparation of query $context failed: ${e.message}")
             e.printStackTrace()
             if (context.txn.type.autoRollback) context.txn.rollback() /* Handle auto-rollback. */
             return flow { throw context.toStatusException(e, false) }


### PR DESCRIPTION
This PR attempts to implement the case where only an order is present, but no limit on unary physical operator nodes.

Additionally, it adds much-needed error information in case something goes wrong during query execution.