### PR TITLE
Fix stack trace with JVM argument

### DIFF
--- a/cottontaildb-dbms/build.gradle
+++ b/cottontaildb-dbms/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 application {
     applicationName = 'cottontaildb'
     mainClassName = 'org.vitrivr.cottontail.CottontailKt'
-    applicationDefaultJvmArgs = ["-Xms2G", "-Xmx4G"]
+    applicationDefaultJvmArgs = ['--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED', "-Xms2G", "-Xmx4G"]
 }
 
 /* Publication of Cottontail DB to Maven Central. */


### PR DESCRIPTION
Adds the required JVM option to allow exodus to access the libraries used. Fixes #156.
Only applies to start scripts generated by gradle, JVM option needs to be manually added when starting JAR directly.